### PR TITLE
Extends enriched K8S metrics with namespace labelled line metrics

### DIFF
--- a/common/k8s/src/middleware/metadata.rs
+++ b/common/k8s/src/middleware/metadata.rs
@@ -147,7 +147,7 @@ impl Middleware for K8sMetadata {
 
                 // NOTE: Not sure if having a side effect is desirable here.
                 // Alternative would be to accumulate additional metrics in the LineBufferMut struct.
-                Metrics::k8s().increment_namespace_lines(&parse_result.pod_namespace);
+                Metrics::fs().increment_lines_with_namespace(&parse_result.pod_namespace);
             }
         }
         Status::Ok(line)

--- a/common/k8s/src/middleware/metadata.rs
+++ b/common/k8s/src/middleware/metadata.rs
@@ -117,6 +117,7 @@ impl Middleware for K8sMetadata {
             if let Some(parse_result) = parse_container_path(file_name) {
                 let obj_ref =
                     ObjectRef::new(&parse_result.pod_name).within(&parse_result.pod_namespace);
+
                 if let Some(pod) = self.store.get(&obj_ref) {
                     if let Some(ref annotations) = pod.metadata.annotations {
                         if line
@@ -143,6 +144,10 @@ impl Middleware for K8sMetadata {
                         };
                     }
                 }
+
+                // NOTE: Not sure if having a side effect is desirable here.
+                // Alternative would be to accumulate additional metrics in the LineBufferMut struct.
+                Metrics::k8s().increment_namespace_lines(&parse_result.pod_namespace);
             }
         }
         Status::Ok(line)


### PR DESCRIPTION
This is enabled by enabling the `ENABLE_K8S_ENRICHMENT` flag to be enabled since it relies on the middleware to identify pod names and namespaces. 